### PR TITLE
add switch for cv2 constant to use based on lemnatech image type (key…

### DIFF
--- a/dsf/data/lemnatec/transfers.py
+++ b/dsf/data/lemnatec/transfers.py
@@ -118,10 +118,8 @@ def _convert_raw_to_png(raw, filename, height, width, dtype, imgtype, bayertype,
             if imgtype == "color":
                 if bayertype == "1":
                     # Convert the Bayer filter raw image into color (BGR)
-                    # Lemnatech's datatype 1 is Bayer BG, we use cv2.COLOR_BAYER_RG2BGR because we want RGB
                     img = cv2.cvtColor(img, cv2.COLOR_BAYER_RG2BGR)
                 elif bayertype == "10":
-                    # Lemnatech's datatype 10 is Bayer RG, we use cv2.COLOR_BAYER_BG2BGR because we want RGB
                     img = cv2.cvtColor(img, cv2.COLOR_BAYER_BG2BGR)
             if flip != 0:
                 # Rotate and flip the image if needed

--- a/dsf/data/lemnatec/transfers.py
+++ b/dsf/data/lemnatec/transfers.py
@@ -82,7 +82,8 @@ def _convert_raw_to_png(raw, filename, height, width, dtype, imgtype, bayertype,
     filename = image filename
     height = height of the image
     width = width of the image
-    imgtype = image data type
+    dtype = data type
+    imgtype = image type
     bayertype = image data format, selects which cv2 constant to use for conversion
     precision = precision (bits) of the raw image values
     flip = flag indicating whether to rotate and flip the image or not
@@ -91,6 +92,7 @@ def _convert_raw_to_png(raw, filename, height, width, dtype, imgtype, bayertype,
     :param filename: str
     :param height: int
     :param width: int
+    :param dtype: str
     :param imgtype: str
     :param bayertype: str
     :param precision: int


### PR DESCRIPTION
Added an if/elif  to use based on lemnatech image type (key in config dataformat dict).

In a recent update lemnatech changed image formats from "1" to "10" which changes the coding from bayerBG to bayerRG. Since we are converting to RGB using `cv2.COLOR_BAYER_RG2BGR` we need to pick the right number to call from `cv2` based on that format from lemnatech.